### PR TITLE
Okto - Rust and Rot additions

### DIFF
--- a/assets/alathraextras/lang/en.json
+++ b/assets/alathraextras/lang/en.json
@@ -1,5 +1,5 @@
 {
-  "game:trait-alchemist": "<font color=\"#84ff84\">• Alchemist</font>",
+  "game:trait-alchemist": "<font color=\"#84ff84\">ï¿½ Alchemist</font>",
   "game:traitname-alchemist": "Alchemist",
   "game:traitdesc-alchemist": "Exclusive craftable <a href=\"handbooksearch://(strong) base \">strong potions</a>"
 }

--- a/assets/alathraextras/patches/alchemy/potionbases.json
+++ b/assets/alathraextras/patches/alchemy/potionbases.json
@@ -82,5 +82,12 @@
 		"path": "/1/requiresTrait",
 		"value": "alchemist",
 		"file": "alchemy:recipes/grid/ingredient/vitalitybase"
+	},
+	{
+		"op": "addmerge",
+		"path": "/requiresTrait",
+		"value": "alchemist",
+		"file": "alchemy:recipes/grid/ingredient/recallbase"
 	}
+
 ]

--- a/assets/alathraextras/patches/rustandrot/boiler.json
+++ b/assets/alathraextras/patches/rustandrot/boiler.json
@@ -11,4 +11,10 @@
     "value": 1,
     "file": "rustandrot:entities/land/rust/boiler2.json"
   }
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/chance",
+    "value": 0.0001,
+    "file": "rustandrot:entities/land/rust/boiler2.json"
+  }
 ]

--- a/assets/alathraextras/patches/rustandrot/boiler.json
+++ b/assets/alathraextras/patches/rustandrot/boiler.json
@@ -10,7 +10,7 @@
     "path": "/server/spawnconditions/runtime/maxLightLevel",
     "value": 1,
     "file": "rustandrot:entities/land/rust/boiler2.json"
-  }
+  },
   {
     "op": "replace",
     "path": "/server/spawnconditions/runtime/chance",

--- a/assets/alathraextras/patches/rustandrot/boiler.json
+++ b/assets/alathraextras/patches/rustandrot/boiler.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxY",
+    "value": 0.1,
+    "file": "rustandrot:entities/land/rust/boiler2.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxLightLevel",
+    "value": 1,
+    "file": "rustandrot:entities/land/rust/boiler2.json"
+  }
+]

--- a/assets/alathraextras/patches/rustandrot/bonemass.json
+++ b/assets/alathraextras/patches/rustandrot/bonemass.json
@@ -10,5 +10,11 @@
     "path": "/server/spawnconditions/runtime/maxLightLevel",
     "value": 1,
     "file": "rustandrot:entities/land/rotten/bonemass.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/chance",
+    "value": 0.0001,
+    "file": "rustandrot:entities/land/rotten/bonemass.json"
   }
 ]

--- a/assets/alathraextras/patches/rustandrot/bonemass.json
+++ b/assets/alathraextras/patches/rustandrot/bonemass.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxY",
+    "value": 0.1,
+    "file": "rustandrot:entities/land/rotten/bonemass.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxLightLevel",
+    "value": 1,
+    "file": "rustandrot:entities/land/rotten/bonemass.json"
+  }
+]

--- a/assets/alathraextras/patches/rustandrot/golem.json
+++ b/assets/alathraextras/patches/rustandrot/golem.json
@@ -1,0 +1,8 @@
+[
+	{
+		"op": "replace",
+		"path": "/server/spawnconditions/runtime/chance",
+		"value": 0,
+		"file": "rustandrot:entities/land/rust/golem.json"
+	}
+]

--- a/assets/alathraextras/patches/rustandrot/itinerant.json
+++ b/assets/alathraextras/patches/rustandrot/itinerant.json
@@ -16,5 +16,11 @@
     "path": "/server/spawnconditions/runtime/maxLightLevel",
     "value": 1,
     "file": "rustandrot:entities/land/rust/itinerant.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/chance",
+    "value": 0.005,
+    "file": "rustandrot:entities/land/rust/itinerant.json"
   }
 ]

--- a/assets/alathraextras/patches/rustandrot/itinerant.json
+++ b/assets/alathraextras/patches/rustandrot/itinerant.json
@@ -1,0 +1,20 @@
+[
+  {
+    "op": "addmerge",
+    "path": "/server/spawnconditions/runtime/maxY",
+    "value": 0.5,
+    "file": "rustandrot:entities/land/rust/itinerant.json"
+  },
+  {
+    "op": "addmerge",
+    "path": "/server/spawnconditions/runtime/minY",
+    "value": 0,
+    "file": "rustandrot:entities/land/rust/itinerant.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxLightLevel",
+    "value": 1,
+    "file": "rustandrot:entities/land/rust/itinerant.json"
+  }
+]

--- a/assets/alathraextras/patches/rustandrot/miasma.json
+++ b/assets/alathraextras/patches/rustandrot/miasma.json
@@ -1,0 +1,20 @@
+[
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxY",
+    "value": 0.6,
+    "file": "rustandrot:entities/land/rotten/miasma.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxLightLevel",
+    "value": 1,
+    "file": "rustandrot:entities/land/rotten/miasma.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/chance",
+    "value": 0.00005,
+    "file": "rustandrot:entities/land/rotten/miasma.json"
+  }
+]

--- a/assets/alathraextras/patches/rustandrot/miasma.json
+++ b/assets/alathraextras/patches/rustandrot/miasma.json
@@ -14,7 +14,7 @@
   {
     "op": "replace",
     "path": "/server/spawnconditions/runtime/chance",
-    "value": 0.00005,
+    "value": 0.0001,
     "file": "rustandrot:entities/land/rotten/miasma.json"
   }
 ]

--- a/assets/alathraextras/patches/rustandrot/mimic.json
+++ b/assets/alathraextras/patches/rustandrot/mimic.json
@@ -1,0 +1,61 @@
+[
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxY",
+    "value": 0.85,
+    "file": "rustandrot:entities/land/rust/mimic.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxLightLevel",
+    "value": 1,
+    "file": "rustandrot:entities/land/rust/mimic.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/behaviors/9/drops",
+    "value": [
+      {
+        "type": "item",
+        "code": "game:metalbit-iron",
+        "quantity": {
+          "avg": 2,
+          "var": 0.5
+        }
+      },
+      {
+        "type": "item",
+        "code": "game:metalbit-copper",
+        "quantity": {
+          "avg": 8,
+          "var": 0.25
+        }
+      },
+      {
+        "type": "item",
+        "code": "game:metalbit-tin",
+        "quantity": {
+          "avg": 4,
+          "var": 0.25
+        }
+      },
+      {
+        "type": "item",
+        "code": "game:salt",
+        "quantity": {
+          "avg": 10,
+          "var": 0.25
+        }
+      },
+      {
+        "type": "item",
+        "code": "game:metal-parts",
+        "quantity": {
+          "avg": 6,
+          "var": 0.5
+        }
+      }
+    ],
+    "file": "rustandrot:entities/land/rust/mimic.json"
+  }
+]

--- a/assets/alathraextras/patches/rustandrot/mimic.json
+++ b/assets/alathraextras/patches/rustandrot/mimic.json
@@ -57,5 +57,11 @@
       }
     ],
     "file": "rustandrot:entities/land/rust/mimic.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/chance",
+    "value": 0.01,
+    "file": "rustandrot:entities/land/rust/mimic.json"
   }
 ]

--- a/assets/alathraextras/patches/rustandrot/roamer.json
+++ b/assets/alathraextras/patches/rustandrot/roamer.json
@@ -27,5 +27,10 @@
     "path": "/server/spawnconditions/runtime/chance",
     "value": 0.03,
     "file": "rustandrot:entities/land/rust/roamer.json"
+  },
+  {
+    "op": "remove",
+    "path": "/server/behaviors/9/aitasks/1",
+    "file": "rustandrot:entities/land/rust/roamer.json"
   }
 ]

--- a/assets/alathraextras/patches/rustandrot/roamer.json
+++ b/assets/alathraextras/patches/rustandrot/roamer.json
@@ -21,5 +21,11 @@
     "path": "/server/spawnconditions/runtime/maxLightLevel",
     "value": 1,
     "file": "rustandrot:entities/land/rust/roamer.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/chance",
+    "value": 0.03,
+    "file": "rustandrot:entities/land/rust/roamer.json"
   }
 ]

--- a/assets/alathraextras/patches/rustandrot/roamer.json
+++ b/assets/alathraextras/patches/rustandrot/roamer.json
@@ -1,0 +1,25 @@
+[
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxY",
+    "value": 0.9,
+    "file": "rustandrot:entities/land/rust/roamer.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/minY",
+    "value": 0.2,
+    "file": "rustandrot:entities/land/rust/roamer.json"
+  },
+  {
+    "op": "remove",
+    "path": "/server/spawnconditions/runtime/companions",
+    "file": "rustandrot:entities/land/rust/roamer.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxLightLevel",
+    "value": 1,
+    "file": "rustandrot:entities/land/rust/roamer.json"
+  }
+]

--- a/assets/alathraextras/patches/rustandrot/rotbeast.json
+++ b/assets/alathraextras/patches/rustandrot/rotbeast.json
@@ -46,5 +46,11 @@
     "op": "remove",
     "path": "/server/spawnconditions/runtime/maxShrubs",
     "file": "rustandrot:entities/land/rotten/rotbeast.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/chance",
+    "value": 0.025,
+    "file": "rustandrot:entities/land/rotten/rotbeast.json"
   }
 ]

--- a/assets/alathraextras/patches/rustandrot/rotbeast.json
+++ b/assets/alathraextras/patches/rustandrot/rotbeast.json
@@ -1,0 +1,50 @@
+[
+  {
+    "op": "addmerge",
+    "path": "/server/spawnconditions/runtime/maxY",
+    "value": 0.8,
+    "file": "rustandrot:entities/land/rotten/rotbeast.json"
+  },
+  {
+    "op": "addmerge",
+    "path": "/server/spawnconditions/runtime/minY",
+    "value": 0.4,
+    "file": "rustandrot:entities/land/rotten/rotbeast.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxLightLevel",
+    "value": 1,
+    "file": "rustandrot:entities/land/rotten/rotbeast.json"
+  },
+  {
+    "op": "remove",
+    "path": "/server/spawnconditions/runtime/minTemp",
+    "file": "rustandrot:entities/land/rotten/rotbeast.json"
+  },
+  {
+    "op": "remove",
+    "path": "/server/spawnconditions/runtime/maxTemp",
+    "file": "rustandrot:entities/land/rotten/rotbeast.json"
+  },
+  {
+    "op": "remove",
+    "path": "/server/spawnconditions/runtime/minRain",
+    "file": "rustandrot:entities/land/rotten/rotbeast.json"
+  },
+  {
+    "op": "remove",
+    "path": "/server/spawnconditions/runtime/minForestOrShrubs",
+    "file": "rustandrot:entities/land/rotten/rotbeast.json"
+  },
+  {
+    "op": "remove",
+    "path": "/server/spawnconditions/runtime/maxForest",
+    "file": "rustandrot:entities/land/rotten/rotbeast.json"
+  },
+  {
+    "op": "remove",
+    "path": "/server/spawnconditions/runtime/maxShrubs",
+    "file": "rustandrot:entities/land/rotten/rotbeast.json"
+  }
+]

--- a/assets/alathraextras/patches/rustandrot/rotcrawler.json
+++ b/assets/alathraextras/patches/rustandrot/rotcrawler.json
@@ -10,5 +10,11 @@
     "path": "/server/spawnconditions/runtime/maxLightLevel",
     "value": 1,
     "file": "rustandrot:entities/land/rotten/rotcrawler.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/chance",
+    "value": 0.01,
+    "file": "rustandrot:entities/land/rotten/rotcrawler.json"
   }
 ]

--- a/assets/alathraextras/patches/rustandrot/rotcrawler.json
+++ b/assets/alathraextras/patches/rustandrot/rotcrawler.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxY",
+    "value": 0.8,
+    "file": "rustandrot:entities/land/rotten/rotcrawler.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxLightLevel",
+    "value": 1,
+    "file": "rustandrot:entities/land/rotten/rotcrawler.json"
+  }
+]

--- a/assets/alathraextras/patches/rustandrot/rotpillar.json
+++ b/assets/alathraextras/patches/rustandrot/rotpillar.json
@@ -1,0 +1,14 @@
+[
+	{
+		"op": "replace",
+		"path": "/server/spawnconditions/runtime/maxY",
+		"value": 0.8,
+		"file": "rustandrot:entities/land/rotten/rotpillar.json"
+	},
+	{
+		"op": "replace",
+		"path": "/server/spawnconditions/runtime/maxLightLevel",
+		"value": 1,
+		"file": "rustandrot:entities/land/rotten/rotpillar.json"
+	}
+]

--- a/assets/alathraextras/patches/rustandrot/rotpillar.json
+++ b/assets/alathraextras/patches/rustandrot/rotpillar.json
@@ -10,5 +10,11 @@
 		"path": "/server/spawnconditions/runtime/maxLightLevel",
 		"value": 1,
 		"file": "rustandrot:entities/land/rotten/rotpillar.json"
+	},
+	{
+		"op": "replace",
+		"path": "/server/spawnconditions/runtime/chance",
+		"value": 0.01,
+		"file": "rustandrot:entities/land/rotten/rotpillar.json"
 	}
 ]

--- a/assets/alathraextras/patches/rustandrot/rotwalker.json
+++ b/assets/alathraextras/patches/rustandrot/rotwalker.json
@@ -24,5 +24,11 @@
     "path": "/server/spawnconditions/runtime/maxLightLevel",
     "value": 1,
     "file": "rustandrot:entities/land/rotten/rotwalker.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/chance",
+    "value": 0.02,
+    "file": "rustandrot:entities/land/rotten/rotwalker.json"
   }
 ]

--- a/assets/alathraextras/patches/rustandrot/rotwalker.json
+++ b/assets/alathraextras/patches/rustandrot/rotwalker.json
@@ -1,0 +1,28 @@
+[
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxYByType",
+    "value": {
+      "*-normal": 0.8,
+      "*-deep": 0.4,
+      "*-blackguard": 0.2
+    },
+    "file": "rustandrot:entities/land/rotten/rotwalker.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/minYByType",
+    "value": {
+      "*-normal": 0.4,
+      "*-deep": 0.2,
+      "*-blackguard": 0
+    },
+    "file": "rustandrot:entities/land/rotten/rotwalker.json"
+  },
+  {
+    "op": "replace",
+    "path": "/server/spawnconditions/runtime/maxLightLevel",
+    "value": 1,
+    "file": "rustandrot:entities/land/rotten/rotwalker.json"
+  }
+]

--- a/modinfo.json
+++ b/modinfo.json
@@ -7,7 +7,7 @@
       "Oktopuss"
     ],
     "description": "Patches for the Alathra server",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "dependencies": {
         "game": "1.19.8"
     }


### PR DESCRIPTION
Added support for the rust and rot mod along with some changes:
 - Rust and rot monsters will now spawn underground. The more basic rust and rot monsters will spawn at higher depths, while the more dangerous ones spawn lower down.
 - Rust and rot monsters are now more common. Roamers and rot walkers spawn at ~1/5 the rate of drifters, with the more dangerous enemies spawning at lower rates
 - Golems have been disabled. They have a 0% chance of spawning, and roamers no long create them.
 - Nerfed loot from mimics. Now only drop iron, copper and tin bits, salt, and metal parts. Previously dropped gold, platinum, and meteoric iron bits, salt, limestone, and metal parts. This was to prevent an easily renewable source of higher tier and quality materials, while still allowing dedicated players/settlements to have an interesting mob that occasionally spawn.
 
Recall potion bases have now been restricted to a alchemist only craft.